### PR TITLE
support symbolic linked directories

### DIFF
--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -1,4 +1,4 @@
-const { existsSync, lstatSync } = require('fs');
+const { existsSync, statSync } = require('fs');
 const { React, getModule } = require('powercord/webpack');
 const { SwitchItem, TextInput, Category } = require('powercord/components/settings');
 
@@ -68,7 +68,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
           defaultValue={this.props.getSetting('filePath')}
           style={!this.state.isFilePathValid ? { borderColor: 'red' } : {}}
           onChange={(value) => {
-            if (value.length === 0 || (existsSync(value) && lstatSync(value).isDirectory())) {
+            if (value.length === 0 || (existsSync(value) && statSync(value).isDirectory())) {
               this.setState({
                 isFilePathValid: true
               });


### PR DESCRIPTION
ehm, I tried to put my pictures directory in the file path input which is (D:\photos) but bcuz I set this path as my pictures library in windows, it became a symbolic link bcuz windows is stupid af.
anyway this will make symbolic linked directories work.
(for some reason the value was replaced with "true" but now it's not)