### PR TITLE
Make the "Clone emote" menu match every other menu on Discord

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,8 +304,7 @@ module.exports = class EmojiUtility extends Plugin {
 
       features.push({
         type: 'submenu',
-        name: 'Clone',
-        hint: 'to',
+        name: 'Clone emote to',
         id: 'emoji-utility-clone',
         onClick: () => onGuildClick(null),
         getItems: getCloneableGuilds


### PR DESCRIPTION
changes
```
Clone           to   >
```
to
```
Clone emote to    >
```